### PR TITLE
feature: [tests] offering more decimal places than expected

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -191,4 +191,80 @@ describe("[user request] proper float precision working", async () => {
     expect(sellOffer.baseAmount).not.to.match(/[0]{4}$/);
     expect(sellConfirm.baseAmount).not.to.match(/[0]{4}$/);
   });
+
+  it("[extrapolating BTC buying precision] - it should pass 15 decimal places and receive 8", async () => {
+    const buyOffer = await api.offer({
+      base: "BTC",
+      amount: 0.123456789012345,
+      op: "buy",
+      isQuote: false,
+    });
+    const buyConfirm = await api.confirmOffer({ offerId: buyOffer.offerId });
+
+    expect(buyOffer.baseAmount).to.be.eq(buyConfirm.baseAmount);
+    expect(buyOffer.quoteAmount).to.be.eq(buyConfirm.quoteAmount);
+
+    expect(buyOffer.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+    expect(buyConfirm.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+
+    expect(buyOffer.baseAmount).to.match(/^\d+(\.\d{8})?$/);
+    expect(buyConfirm.baseAmount).to.match(/^\d+(\.\d{8})?$/);
+  });
+
+  it("[extrapolating BTC selling precision] - it should pass 15 decimal places and receive 8", async () => {
+    const sellOffer = await api.offer({
+      base: "BTC",
+      amount: 0.123456789012345,
+      op: "sell",
+      isQuote: false,
+    });
+    const sellConfirm = await api.confirmOffer({ offerId: sellOffer.offerId });
+
+    expect(sellOffer.baseAmount).to.be.eq(sellConfirm.baseAmount);
+    expect(sellOffer.quoteAmount).to.be.eq(sellConfirm.quoteAmount);
+
+    expect(sellOffer.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+    expect(sellConfirm.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+
+    expect(sellOffer.baseAmount).to.match(/^\d+(\.\d{8})?$/);
+    expect(sellConfirm.baseAmount).to.match(/^\d+(\.\d{8})?$/);
+  });
+
+  it("[extrapolating ETH buying precision] - it should pass 15 decimal places and receive 12", async () => {
+    const buyOffer = await api.offer({
+      base: "ETH",
+      amount: 0.123456789012345,
+      op: "buy",
+      isQuote: false,
+    });
+    const buyConfirm = await api.confirmOffer({ offerId: buyOffer.offerId });
+
+    expect(buyOffer.baseAmount).to.be.eq(buyConfirm.baseAmount);
+    expect(buyOffer.quoteAmount).to.be.eq(buyConfirm.quoteAmount);
+
+    expect(buyOffer.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+    expect(buyConfirm.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+
+    expect(buyOffer.baseAmount).to.match(/^\d+(\.\d{12})?$/);
+    expect(buyConfirm.baseAmount).to.match(/^\d+(\.\d{12})?$/);
+  });
+
+  it("[extrapolating ETH selling precision] - it should pass 15 decimal places and receive 12", async () => {
+    const sellOffer = await api.offer({
+      base: "ETH",
+      amount: 0.123456789012345,
+      op: "sell",
+      isQuote: false,
+    });
+    const sellConfirm = await api.confirmOffer({ offerId: sellOffer.offerId });
+
+    expect(sellOffer.baseAmount).to.be.eq(sellConfirm.baseAmount);
+    expect(sellOffer.quoteAmount).to.be.eq(sellConfirm.quoteAmount);
+
+    expect(sellOffer.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+    expect(sellConfirm.baseAmount).not.to.match(/^\d+(\.\d{15})?$/);
+
+    expect(sellOffer.baseAmount).to.match(/^\d+(\.\d{12})?$/);
+    expect(sellConfirm.baseAmount).to.match(/^\d+(\.\d{12})?$/);
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -267,4 +267,10 @@ describe("[user request] proper float precision working", async () => {
     expect(sellOffer.baseAmount).to.match(/^\d+(\.\d{12})?$/);
     expect(sellConfirm.baseAmount).to.match(/^\d+(\.\d{12})?$/);
   });
+
+  it.only("[Date typing on user demand] Verifies the type of trades' dates", async () => {
+    const trades = await api.trades();
+    
+    expect(new Date(trades[0].date).toISOString()).to.be.equal(trades[0].date);
+  });
 });


### PR DESCRIPTION
Last tests on demand. Monitoring how our API behaves when faced with more decimal places than expected.

It passes 15 decimal places on buyOffer and confirmOffer for both BTC and ETH. It should receive a 8 and 12 decimal places for both, respectivelly.

It also passes 15 decimal places on sellOffer and confirmSellOffer for both BTC and ETH. It should receive a 8 and 12 decimal places for both, respectivelly.

Tests passing ok.